### PR TITLE
chore: add sid for policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,8 @@ data "aws_iam_policy_document" "main" {
   for_each = var.s3_buckets
 
   statement {
+    sid = "DenyInsecureTransportProtocol"
+
     actions = ["s3:*"]
     resources = [
       "arn:aws:s3:::${each.value.bucket}",


### PR DESCRIPTION
- New behaviour from AWS/Terraform always adds a default SID of `1`, which results in changes in state every time we apply
- Set SID so that we stop seeing this change

Proof that `1` shows up in bucket policy in AWS console
<img width="407" alt="image" src="https://github.com/user-attachments/assets/db441066-a48a-46b7-98c8-d39e9f8219fa">

Proof that there's a change in TF state every time I apply
<img width="993" alt="image" src="https://github.com/user-attachments/assets/af8161b0-a713-492a-9d64-39b45cfe23ad">
