### PR TITLE
feat: allow optional access bucket logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,23 +46,13 @@ module "s3-generic" {
 }
 ```
 
-## Requirements
-
-No requirements.
-
-## Providers
-
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_force_destroy"></a> [force\_destroy](#input\_force\_destroy) | When destroying this user, destroy even if it has non-Terraform-managed IAM access keys, login profile or MFA devices. Without force\_destroy a user with non-Terraform-managed access keys and login profile will fail to be destroyed. | `bool` | `false` | no |
 | <a name="input_path"></a> [path](#input\_path) | Desired path for the IAM user | `string` | `"/"` | no |
-| <a name="input_s3_buckets"></a> [s3\_buckets](#input\_s3\_buckets) | A map of bucket names to an object describing the S3 bucket settings for the bucket. | <pre>map(object({<br>    bucket                               = string<br>    permissions_boundary                 = string<br>    region                               = string<br>    acl                                  = optional(string)<br>    log_bucket_for_s3                    = string<br>    policies                             = list(string)<br>    server_side_encryption_configuration = any<br>    cors_configuration                   = optional(<br>      list(<br>        object({<br>          allowed_methods = list(string)<br>          allowed_origins = list(string)<br>          allowed_headers = optional(list(string))<br>          expose_headers  = optional(list(string))<br>          max_age_seconds = optional(number)<br>          id              = optional(string)<br>        })<br>      )<br>    )<br>  }))</pre> | <pre>{<br>  "main": {<br>    "bucket": "",<br>    "log_bucket_for_s3": "",<br>    "permissions_boundary": "",<br>    "policies": [],<br>    "region": "ap-southeast-1",<br>    "server_side_encryption_configuration": {<br>      "rule": {<br>        "apply_server_side_encryption_by_default": {<br>          "sse_algorithm": "AES256"<br>        }<br>      }<br>    }<br>  }<br>}</pre> | no |
+| <a name="input_s3_buckets"></a> [s3\_buckets](#input\_s3\_buckets) | A map of bucket names to an object describing the S3 bucket settings for the bucket. | <pre>map(object({<br/>    bucket                               = string<br/>    permissions_boundary                 = string<br/>    region                               = string<br/>    acl                                  = optional(string)<br/>    log_bucket_for_s3                    = optional(string)<br/>    policies                             = list(string)<br/>    server_side_encryption_configuration = any<br/>    cors_configuration                   = optional(<br/>      list(<br/>        object({<br/>          allowed_methods = list(string)<br/>          allowed_origins = list(string)<br/>          allowed_headers = optional(list(string))<br/>          expose_headers  = optional(list(string))<br/>          max_age_seconds = optional(number)<br/>          id              = optional(string)<br/>        })<br/>      )<br/>    )<br/>  }))</pre> | <pre>{<br/>  "main": {<br/>    "bucket": "",<br/>    "log_bucket_for_s3": "",<br/>    "permissions_boundary": "",<br/>    "policies": [],<br/>    "region": "ap-southeast-1",<br/>    "server_side_encryption_configuration": {<br/>      "rule": {<br/>        "apply_server_side_encryption_by_default": {<br/>          "sse_algorithm": "AES256"<br/>        }<br/>      }<br/>    }<br/>  }<br/>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | (Optional) A mapping of tags to assign to the bucket. | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -5,7 +5,7 @@ variable "s3_buckets" {
     permissions_boundary                 = string
     region                               = string
     acl                                  = optional(string)
-    log_bucket_for_s3                    = string
+    log_bucket_for_s3                    = optional(string)
     policies                             = list(string)
     server_side_encryption_configuration = any
     cors_configuration                   = optional(


### PR DESCRIPTION
- make `log_bucket_for_s3` optional
- so that the access log bucket itself is not forced to log into itself or somewhere else

> Your destination bucket should not have server access logging enabled. You can have logs delivered to any bucket that you own that is in the same Region as the source bucket, including the source bucket itself. However, delivering logs to the source bucket will cause an infinite loop of logs and is not recommended.
> https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html

