### PR TITLE
Add tags for AWS Backup tag selection 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,6 +32,8 @@ resource "aws_s3_bucket" "main" {
   for_each = var.s3_buckets
 
   bucket = each.value.bucket
+  
+  tags_all = var.tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "main" {


### PR DESCRIPTION
The tags are currently not added to the S3 buckets - so Backup is unable to the buckets provisioned through this module properly if the selection criterion is set on tags