### PR TITLE
Add object lock to S3 bucket configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -32,7 +32,9 @@ resource "aws_s3_bucket" "main" {
   for_each = var.s3_buckets
 
   bucket = each.value.bucket
-  
+
+  object_lock_enabled = var.object_lock_enabled
+
   tags_all = var.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,12 @@ variable "path" {
   default     = "/"
 }
 
+variable "object_lock_enabled" {
+  description = "(Optional) Enable object lock for the S3 bucket"
+  type        = bool
+  default     = false
+}
+
 variable "tags" {
   description = "(Optional) A mapping of tags to assign to the bucket."
   type        = map(string)


### PR DESCRIPTION
`object_lock_enabled` is currently not configured on S3 buckets - to add this in as an optional configuration and default to false if not specified