### PR TITLE
Use tags argument over tags_all attribute

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_s3_bucket" "main" {
 
   object_lock_enabled = var.object_lock_enabled
 
-  tags_all = var.tags
+  tags = var.tags
 }
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "main" {


### PR DESCRIPTION
Using `tags_all` causes the resource to alternate between creating and deleting tags forever.

The argument for the resource should be [tags](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#tags-1). On the other hand, [tags_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket#tags_all-1) is just attribute of the created resource.