### PR TITLE
fix: Update S3 bucket ownership controls configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -81,7 +81,7 @@ resource "aws_s3_bucket_ownership_controls" "main" {
   ]
 
   rule {
-    object_ownership = lookup(each.value, "object_ownership", var.object_ownership)
+    object_ownership = each.value.object_ownership != null ? each.value.object_ownership : var.object_ownership
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,13 @@
 variable "s3_buckets" {
   description = "A map of bucket names to an object describing the S3 bucket settings for the bucket."
+
+  validation {
+    condition = alltrue([for bucket in var.s3_buckets :
+      bucket.object_ownership == null ? true : 
+      contains(["BucketOwnerEnforced", "BucketOwnerPreferred", "ObjectWriter"], bucket.object_ownership)
+    ])
+    error_message = "When specified, bucket-level object_ownership must be one of: BucketOwnerEnforced, BucketOwnerPreferred, or ObjectWriter."
+  }
   type = map(object({
     bucket                               = string
     permissions_boundary                 = string


### PR DESCRIPTION
- Simplify object_ownership assignment using ternary operator
- Remove complex coalesce/try expressions for better reliability

This change ensures that object_ownership is properly set for all buckets, while maintaining the ability to override it at the bucket level. The simpler logic makes the code more maintainable and less prone to errors.