### PR TITLE
fix lifecycle filter

### DIFF
--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -41,6 +41,9 @@ module "s3-generic" {
           enabled = true
           filter = {
             object_size_greater_than = 0
+            tags = {
+              GuardDutyMalwareScanStatus = "THREATS_FOUND"
+            }
           }
           transition = [
             {

--- a/variables.tf
+++ b/variables.tf
@@ -38,7 +38,7 @@ variable "s3_buckets" {
         prefix                   = optional(string)
         object_size_greater_than = optional(number)
         object_size_less_than    = optional(number)
-        tags                     = optional(map(string))
+        tags                     = optional(map(string), {})
       }))
       transition = optional(list(object({
         days          = optional(number)


### PR DESCRIPTION
**Context**

Trying to add different types of lifecycle filter to different bucket, getting various errors such as: `Invalid value for "inputMap" parameter: argument must not be null.`, or that the tag is not being picked up by the module no matter how I structure the input.

- fixed condition with lifecycle filter
- split filter block due to [bug in AWS provider](https://github.com/hashicorp/terraform-provider-aws/issues/41710)
- updated example to include lifecycle filter tag

Manually tested these permutations in Terragrunt

- buckets with/without lifecycle
- buckets with single/multiple tags, with/without other filters
- buckets going from 0 filters to 1, to 2 filters
- buckets going from 1/2 filters to 0 filters

Following the [upstream module's](https://github.com/terraform-aws-modules/terraform-aws-s3-bucket) way of structuring results in errors one way or another.